### PR TITLE
add support for next links [B2C-983]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,10 +7,13 @@
     "es6": true,
     "jest": true
   },
-  "overrides": [{
+  "overrides": [
+    {
       "files": "test/**/*.js",
       "rules": {
-        "react/jsx-filename-extension": 0
+        "react/jsx-filename-extension": 0,
+        "jsx-a11y/anchor-is-valid": 0
       }
-  }]
+    }
+  ]
 }

--- a/src/components/atoms/Link.jsx
+++ b/src/components/atoms/Link.jsx
@@ -1,54 +1,60 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { getTypeClassNames, TYPOGRAPHY_PROP_TYPES } from '../../utils/typographyUtils';
 
-const Link = ({
-    children,
-    type = 'link',
-    className,
-    href,
-    onClick,
-    weight,
-    height,
-    state,
-    alignment,
-    capitalization,
-    list,
-    truncate,
-    opaque,
-    ...attributes
-}) => {
-    Link.propTypes = {
-        children: PropTypes.node,
-        className: PropTypes.string,
-        href: PropTypes.string.isRequired,
-        type: PropTypes.oneOf(['link', 'anchor']),
-        onClick: PropTypes.func,
-        ...TYPOGRAPHY_PROP_TYPES
-    };
+const Link = forwardRef(
+    (
+        {
+            children,
+            type = 'link',
+            className,
+            href,
+            onClick,
+            weight,
+            height,
+            state,
+            alignment,
+            capitalization,
+            list,
+            truncate,
+            opaque,
+            ...attributes
+        },
+        ref
+    ) => {
+        Link.propTypes = {
+            children: PropTypes.node,
+            className: PropTypes.string,
+            href: PropTypes.string,
+            type: PropTypes.oneOf(['link', 'anchor']),
+            onClick: PropTypes.func,
+            ...TYPOGRAPHY_PROP_TYPES
+        };
 
-    const baseClassName = type === 'anchor' ? 'vdp-anchor' : 'vdp-type-link';
-    const linkClassNames = getTypeClassNames(baseClassName, {
-        weight,
-        height,
-        state,
-        alignment,
-        capitalization,
-        truncate,
-        list,
-        opaque,
-        className
-    });
+        const baseClassName = type === 'anchor' ? 'vdp-anchor' : 'vdp-type-link';
+        const linkClassNames = getTypeClassNames(baseClassName, {
+            weight,
+            height,
+            state,
+            alignment,
+            capitalization,
+            truncate,
+            list,
+            opaque,
+            className
+        });
 
-    const props = {
-        href,
-        onClick,
-        role: 'link',
-        className: linkClassNames,
-        ...attributes
-    };
+        const props = {
+            href,
+            onClick,
+            role: 'link',
+            className: linkClassNames,
+            ref,
+            ...attributes
+        };
 
-    return <a {...props}>{children}</a>;
-};
+        return <a {...props}>{children}</a>;
+    }
+);
 
 export default Link;

--- a/test/Link/LinkSpec.js
+++ b/test/Link/LinkSpec.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import React, { useRef } from 'react';
+import { shallow, mount } from 'enzyme';
 import Link from '../../src/components/atoms/Link';
 
 describe('<Link />', () => {
@@ -20,5 +20,21 @@ describe('<Link />', () => {
         const wrapper = shallow(<Link href={fakeHref} onClick={mockOnClick} />);
         wrapper.find('.vdp-type-link').simulate('click');
         expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow for no href prop', () => {
+        const wrapper = shallow(<Link id="myLink" />);
+        expect(wrapper.find('#myLink').props().href).toBe(undefined);
+    });
+
+    it('should forward ref to anchor tag', () => {
+        let ref;
+        const TestRef = () => {
+            ref = useRef();
+            return <Link ref={ref} id="myLink" />;
+        };
+
+        mount(<TestRef />);
+        expect(ref.current).toBeTruthy();
     });
 });


### PR DESCRIPTION
Next requires an anchor tag with no href and to forward refs to the anchor tags. This adds support for that.

https://nextjs.org/docs/api-reference/next/link